### PR TITLE
fixed series command with text values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.axibase</groupId>
     <artifactId>atsd-api-java</artifactId>
-    <version>0.5.15</version>
+    <version>0.5.16-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <prerequisites>

--- a/src/main/java/com/axibase/tsd/network/InsertCommand.java
+++ b/src/main/java/com/axibase/tsd/network/InsertCommand.java
@@ -50,7 +50,7 @@ public class InsertCommand extends AbstractInsertCommand {
     protected void appendValues(StringBuilder sb) {
         sb.append(" m:").append(handleStringValue(metricName)).append('=').append(formatMetricValue(sample.getNumericValue()));
         if (StringUtils.isNotEmpty(sample.getTextValue())) {
-            sb.append(" x:").append(handleStringValue(metricName)).append('=').append(sample.getTextValue());
+            sb.append(" x:").append(handleStringValue(metricName)).append('=').append(handleStringValue(sample.getTextValue()));
         }
     }
 

--- a/src/test/java/com/axibase/tsd/client/command/CommandSeriesQuotesTest.java
+++ b/src/test/java/com/axibase/tsd/client/command/CommandSeriesQuotesTest.java
@@ -50,7 +50,7 @@ public class CommandSeriesQuotesTest {
                 testSeries.getTags()
         );
         Sample testSample = testSeries.getData().get(0);
-        assertEquals("Commands is composing incorrectly",
+        assertEquals("Command is composing incorrectly",
                 String.format("series e:\"%s\" ms:%d t:tag=\"OFF- RAMP \"\" U\"\", I\" m:\"%s\"=%s x:\"%s\"=%s\n",
                         TEST_ENTITY, testSample.getTimeMillis(), TEST_METRIC, testSample.getNumericValue(), TEST_METRIC, testSample.getTextValue()),
                 command.compose()
@@ -78,5 +78,27 @@ public class CommandSeriesQuotesTest {
         assertEquals(testSeries.getData(), actualSeries.getData());
         assertEquals(testSeries.getTags(), actualSeries.getTags());
 
+    }
+
+    @Test
+    public void testComposeSeriesCommandWithSpaceInText() {
+        final long time = 1488800000000L;
+        PlainCommand command = new InsertCommand(
+                "test-entity",
+                "test-metric",
+                new Sample(time, Double.NaN, "Value With Space")
+        );
+        assertEquals("series e:\"test-entity\" ms:1488800000000 m:\"test-metric\"=NaN x:\"test-metric\"=\"Value With Space\"", command.compose().trim());
+    }
+
+    @Test
+    public void testCoposeSeriesCommandWithQuotesInText() {
+        final long time = 1488800000000L;
+        PlainCommand command = new InsertCommand(
+                "test-entity",
+                "test-metric",
+                new Sample(time, Double.NaN, "a \"Quoted\" value")
+        );
+        assertEquals("series e:\"test-entity\" ms:1488800000000 m:\"test-metric\"=NaN x:\"test-metric\"=\"a \"\"Quoted\"\" value\"", command.compose().trim());
     }
 }

--- a/src/test/java/com/axibase/tsd/client/command/CommandSeriesQuotesTest.java
+++ b/src/test/java/com/axibase/tsd/client/command/CommandSeriesQuotesTest.java
@@ -50,8 +50,8 @@ public class CommandSeriesQuotesTest {
                 testSeries.getTags()
         );
         Sample testSample = testSeries.getData().get(0);
-        assertEquals("Command is composing incorrectly",
-                String.format("series e:\"%s\" ms:%d t:tag=\"OFF- RAMP \"\" U\"\", I\" m:\"%s\"=%s x:\"%s\"=%s\n",
+        assertEquals("Command has been composed incorrectly",
+                String.format("series e:\"%s\" ms:%d t:tag=\"OFF- RAMP \"\" U\"\", I\" m:\"%s\"=%s x:\"%s\"=\"%s\"\n",
                         TEST_ENTITY, testSample.getTimeMillis(), TEST_METRIC, testSample.getNumericValue(), TEST_METRIC, testSample.getTextValue()),
                 command.compose()
         );


### PR DESCRIPTION
Fixed an issue with commands parsing failure because text values were not quoted.