### PR TITLE
fixed error 'IOException: Stream closed'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.axibase</groupId>
     <artifactId>atsd-api-java</artifactId>
-    <version>0.5.19</version>
+    <version>0.5.20-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <prerequisites>
@@ -56,7 +56,8 @@
         <jersey.version>2.15</jersey.version>
         <!--<jersey.version>2.6</jersey.version>-->
         <jackson.version>2.7.3</jackson.version>
-        <slf4j.version>1.7.22</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <logback.version>1.2.3</logback.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -71,6 +72,12 @@
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache-connector</artifactId>
             <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-logging</artifactId>
+                    <groupId>commons-logging</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--Logging-->
         <dependency>
@@ -84,9 +91,14 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.13</version>
+            <version>${logback.version}</version>
         </dependency>
         <!--Utils-->
         <dependency>

--- a/src/main/java/com/axibase/tsd/client/AtsdServerException.java
+++ b/src/main/java/com/axibase/tsd/client/AtsdServerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Axibase Corporation or its affiliates. All Rights Reserved.
+ * Copyright 2017 Axibase Corporation or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,17 +14,24 @@
  */
 package com.axibase.tsd.client;
 
+import lombok.Getter;
+
 /**
  * Thrown if an error is returned from the ATSD server.
- *
- * @author Nikolay Malevanny.
  */
 public class AtsdServerException extends RuntimeException {
-    public AtsdServerException(String message) {
+
+    @Getter
+    private final int status;
+
+    public AtsdServerException(String message, int status) {
         super(message);
+        this.status = status;
     }
 
-    public AtsdServerException(String message, Throwable cause) {
+    public AtsdServerException(String message, int status, Throwable cause) {
         super(message, cause);
+        this.status = status;
     }
+
 }

--- a/src/test/java/com/axibase/tsd/client/metadata/EntityTest.java
+++ b/src/test/java/com/axibase/tsd/client/metadata/EntityTest.java
@@ -24,6 +24,8 @@ import com.axibase.tsd.client.HttpClientManager;
 import com.axibase.tsd.client.MetaDataService;
 import com.axibase.tsd.model.meta.Entity;
 import com.axibase.tsd.model.meta.TagAppender;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -204,6 +206,17 @@ public class EntityTest {
 
         assertTrue(metaDataService.deleteEntity(entity));
         assertNull(metaDataService.retrieveEntity(entityName));
+    }
+
+    @Test
+    public void testDeleteNonexistentEntity() throws Exception {
+        final String entityName = buildVariablePrefix();
+        try {
+            assertFalse(metaDataService.deleteEntity(createEntity(entityName)));
+        } catch (AtsdServerException exc) {
+            assertTrue(StringUtils.contains(exc.getMessage(), entityName));
+            assertEquals(HttpStatus.SC_NOT_FOUND, exc.getStatus());
+        }
     }
 
     private static Entity createEntity(String entityName) {


### PR DESCRIPTION
fixed error 'IOException: Stream closed' when executing 'response.readEntity(ServerError.class)' and made some refactoring.