### PR TITLE
fix not set header[Set header for each request]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get started by importing the client with **Maven**:
     <dependency>
       <groupId>com.axibase</groupId>
       <artifactId>atsd-api-java</artifactId>
-      <version>1.07</version>
+      <version>1.0.7</version>
     </dependency>
 ```
 
@@ -78,7 +78,7 @@ git clone https://github.com/axibase/atsd-api-java.git
 cd atsd-api-java
 mvn clean dependency:copy-dependencies compile jar:jar
 cd target
-java -cp "atsd-api-java-1.07.jar:dependency/*" -Daxibase.tsd.api.client.properties=./client.properties com.axibase.tsd.example.AtsdClientWriteExample
+java -cp "atsd-api-java-1.0.7.jar:dependency/*" -Daxibase.tsd.api.client.properties=./client.properties com.axibase.tsd.example.AtsdClientWriteExample
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get started by importing the client with **Maven**:
     <dependency>
       <groupId>com.axibase</groupId>
       <artifactId>atsd-api-java</artifactId>
-      <version>1.0.6</version>
+      <version>1.07</version>
     </dependency>
 ```
 
@@ -78,7 +78,7 @@ git clone https://github.com/axibase/atsd-api-java.git
 cd atsd-api-java
 mvn clean dependency:copy-dependencies compile jar:jar
 cd target
-java -cp "atsd-api-java-1.0.6.jar:dependency/*" -Daxibase.tsd.api.client.properties=./client.properties com.axibase.tsd.example.AtsdClientWriteExample
+java -cp "atsd-api-java-1.07.jar:dependency/*" -Daxibase.tsd.api.client.properties=./client.properties com.axibase.tsd.example.AtsdClientWriteExample
 ```
 
 ## Examples

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.axibase</groupId>
     <artifactId>atsd-api-java</artifactId>
-    <version>1.07</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.axibase</groupId>
     <artifactId>atsd-api-java</artifactId>
-    <version>1.0.6</version>
+    <version>1.07</version>
     <packaging>jar</packaging>
 
     <prerequisites>

--- a/src/main/java/com/axibase/tsd/client/ClientConfigurationFactory.java
+++ b/src/main/java/com/axibase/tsd/client/ClientConfigurationFactory.java
@@ -31,7 +31,6 @@ public class ClientConfigurationFactory {
     private static final String DEFAULT_CLIENT_PROPERTIES_FILE_NAME = "classpath:/client.properties";
     private static final String AXIBASE_TSD_API_DOMAIN = "axibase.tsd.api";
     private static final String DEFAULT_API_PATH = "/api/v1";
-    public static final String DEFAULT_USERNAME = "atsd-api-java";
 
     private String protocol;
     private String serverName;
@@ -115,7 +114,7 @@ public class ClientConfigurationFactory {
         configurationFactory.ignoreSSLErrors = extractor.getAsBoolean("ssl.errors.ignore", false);
         configurationFactory.skipStreamingControl = extractor.getAsBoolean("streaming.control.skip", false);
         configurationFactory.enableGzipCompression = extractor.getAsBoolean("compression.gzip.enable", false);
-        configurationFactory.userAgent = extractor.getAsString("user.agent", DEFAULT_USERNAME);
+        configurationFactory.userAgent = extractor.getAsString("user.agent", StringUtils.EMPTY);
         return configurationFactory;
     }
 

--- a/src/main/java/com/axibase/tsd/client/HttpClient.java
+++ b/src/main/java/com/axibase/tsd/client/HttpClient.java
@@ -92,7 +92,6 @@ class HttpClient {
     private static Client buildClient(ClientConfiguration clientConfiguration) {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig
-                .property(HttpHeaders.USER_AGENT, HttpUtils.compileUserAgent(clientConfiguration.getClientName()))
                 .register(JsonMappingExceptionMapper.class)
                 .register(JsonParseExceptionMapper.class)
                 .register(JacksonJaxbJsonProvider.class, MessageBodyReader.class, MessageBodyWriter.class)
@@ -280,7 +279,8 @@ class HttpClient {
         target = query.fill(target);
 
         log.debug("url = {}", target.getUri());
-        Invocation.Builder request = target.request(mediaType);
+        Invocation.Builder request = target.request(mediaType)
+                .header(HttpHeaders.USER_AGENT, HttpUtils.compileUserAgent(clientConfiguration.getClientName()));
 
         Response response = null;
         try {

--- a/src/test/java/com/axibase/tsd/client/UserAgentTest.java
+++ b/src/test/java/com/axibase/tsd/client/UserAgentTest.java
@@ -1,6 +1,7 @@
 package com.axibase.tsd.client;
 
 import com.axibase.tsd.TestUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +18,6 @@ public class UserAgentTest {
     public void testUserAgent() {
         final String actual = client.getClientConfiguration().getClientName();
         final String message = "User-agent value is different from default";
-        Assert.assertEquals(message, "atsd-api-java", actual);
+        Assert.assertEquals(message, StringUtils.EMPTY, actual);
     }
 }


### PR DESCRIPTION
The new method set header for each request via `Invocation.Builder`

Logs of HTTP requests from apache client :

```txt
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.headers - http-outgoing-1 >> Cookie2: $Version=1
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.headers - http-outgoing-1 >> Accept-Encoding: gzip,deflate
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "GET /api/v1/entity-groups/test-create-and-delete-entity-group-without-tags%3Atst- HTTP/1.1[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Accept: application/json[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "User-Agent: atsd-api-java[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Authorization: Basic YXhpYmFzZTpheGliYXNl[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Host: localhost:8088[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Connection: Keep-Alive[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Cookie: ATSD_SESSION_ID=node01tmzo19q9xk4o16s7kbhxdjw68223.node0[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Cookie2: $Version=1[\r][\n]"
2018-08-03T21:11:32.771 DEBUG [main] org.apache.http.wire - http-outgoing-1 >> "Accept-Encoding: gzip,deflate[\r][\n]"

```
